### PR TITLE
BUG: set-dev script fails with default package

### DIFF
--- a/set-common-dev
+++ b/set-common-dev
@@ -9,7 +9,7 @@ if [ -z "$1" ]; then
 fi
 
 REPO="$1"
-PACKAGE=${2:-${MODULE}}
+PACKAGE=${2:-${REPO}}
 ORG=${3:-"pcdshub"}
 
 HERE=`dirname $(readlink -f $0)`

--- a/set-dev
+++ b/set-dev
@@ -9,7 +9,7 @@ if [ -z "$1" ]; then
 fi
 
 REPO="$1"
-PACKAGE=${2:-${MODULE}}
+PACKAGE=${2:-${REPO}}
 ORG=${3:-"pcdshub"}
 
 HERE=`dirname $(readlink -f $0)`


### PR DESCRIPTION
Defaults to empty string instead of $REPO because $MODULE is not defined, causing the symbolic link to be made incorrectly.