### PR TITLE
BUG: Properly pass daq config params, disable bec plots for delay_scan

### DIFF
--- a/experiments/ly5320.py
+++ b/experiments/ly5320.py
@@ -21,11 +21,14 @@ from pcdsdevices.areadetector import plugins
 from xcs.db import daq
 from xcs.db import camviewer
 from xcs.db import RE
+from xcs.db import bec
 from xcs.db import xcs_ccm as ccm
 from xcs.delay_scan import delay_scan
 from xcs.db import lxt_fast, lxt_fast_enc
 from pcdsdevices.device_types import Newport, IMS
 from pcdsdevices.evr import Trigger
+
+from nabs.plans import daq_delay_scan
 #from macros import *
 import time
 
@@ -140,17 +143,19 @@ class User():
 
     def delay_scan(self, start, end, sweep_time, record=True, use_l3t=False,
                    duration=None):
-        """Delay scan with the daq."""
+        """Delay scan with the daq.  Uses nabs.plans.delay_scan"""
         self.cleanup_RE()
-        daq.configure(events=None, duration=duration, record=record,
-                      use_l3t=use_l3t, controls=[lxt_fast])
+        bec.disable_plots()
+        controls = [lxt_fast]
         try:
             RE(delay_scan(daq, lxt_fast, [start, end], sweep_time,
-                          duration=duration))
+                          duration=duration, record=record, use_l3t=use_l3t,
+                          controls=controls))
         except Exception:
             logger.debug('RE Exit', exc_info=True)
         finally:
             self.cleanup_RE()
+            bec.enable_plots()
 
     def empty_delay_scan(self, start, end, sweep_time, record=True,
                          use_l3t=False, duration=None):

--- a/experiments/ly5320.py
+++ b/experiments/ly5320.py
@@ -28,7 +28,6 @@ from xcs.db import lxt_fast, lxt_fast_enc
 from pcdsdevices.device_types import Newport, IMS
 from pcdsdevices.evr import Trigger
 
-from nabs.plans import daq_delay_scan
 #from macros import *
 import time
 
@@ -143,7 +142,7 @@ class User():
 
     def delay_scan(self, start, end, sweep_time, record=True, use_l3t=False,
                    duration=None):
-        """Delay scan with the daq.  Uses nabs.plans.delay_scan"""
+        """Delay scan with the daq."""
         self.cleanup_RE()
         bec.disable_plots()
         controls = [lxt_fast]

--- a/xcs/delay_scan.py
+++ b/xcs/delay_scan.py
@@ -10,7 +10,8 @@ from scipy.constants import speed_of_light
 from pcdsdaq.preprocessors import daq_during_wrapper
 from pcdsdevices.interface import BaseInterface
 
-def delay_scan(daq, time_motor, time_points, sweep_time, duration=None):
+def delay_scan(daq, time_motor, time_points, sweep_time, duration=None, 
+               record=None, use_l3t=False, controls=None):
     """
     Bluesky plan that sets up and executes the delay scan.
 
@@ -28,8 +29,18 @@ def delay_scan(daq, time_motor, time_points, sweep_time, duration=None):
     sweep_time: float
         The duration we take to move from one end of the range to the other.
 
-    duration: float
+    record: bool, optional
+        Whether or not to record in the daq
+
+    duration: float, optional
         If provided, the time to run in seconds. If omitted, we'll run forever.
+
+    use_l3t: bool, optional
+        If True, events argument will be interpreted to only count events that
+        pass the level 3 trigger
+
+    controls: dict or list of devices, optional
+        If provided, values will make it to DAQ data stream as variables
     """
 
     spatial_pts = []
@@ -46,7 +57,8 @@ def delay_scan(daq, time_motor, time_points, sweep_time, duration=None):
     scan = infinite_scan([], time_motor, time_points, duration=duration)
 
     if daq is not None:
-        yield from daq_during_wrapper(scan)
+        yield from daq_during_wrapper(scan, record=record, use_l3t=use_l3t,
+                                      controls=controls)
     else:
         yield from scan
 


### PR DESCRIPTION
## Description
Fixed some delay_scan bugs.  I did not use `nabs.plans.delay_scan` for this, as the existing implementation seems to want to pass in specific controls and use_l3t trigger settings, which the nabs library scan assumes behavior for.  

Previously, parameters weren't being passed through to `daq_during_wrapper`, causing the plan to never record.  

## Motivation and Context
[Jira ticket 1](https://jira.slac.stanford.edu/browse/LCLSECSD-750)
[Jira ticket 2](https://jira.slac.stanford.edu/browse/LCLSECSD-751)

## How Has This Been Tested?
Hasn't yet, I'm not sure how to properly test this without access to real motors and the daq

## Where Has This Been Documented?
Docstrings, to an extent